### PR TITLE
Support for remote monitoring application via rpc

### DIFF
--- a/DynMiner2/DynMiner2.cpp
+++ b/DynMiner2/DynMiner2.cpp
@@ -159,13 +159,14 @@ void parseCommandArgs(int argc, char* argv[]) {
         if (commandArgs.find("-minername") == commandArgs.end())
             showUsage("-minername is required when using -statrpcurl");
 
-        printf("Sending stats to URL: %s \n", statURL.c_str());
+        if (commandArgs.find("-minername") != commandArgs.end()) {
+            multimap<string, string>::iterator it = commandArgs.find("-minername");
+            minerName = it->second;
+        }
+
+        printf("Sending stats to URL: %s using miner name %s\n", statURL.c_str(), minerName.c_str());
     }
 
-    if (commandArgs.find("-minername") != commandArgs.end()) {
-        multimap<string, string>::iterator it = commandArgs.find("-minername");
-        minerName = it->second;
-    }
 
     if (commandArgs.find("-server") == commandArgs.end())
         showUsage("Missing argument: server");

--- a/DynMiner2/DynMiner2.cpp
+++ b/DynMiner2/DynMiner2.cpp
@@ -34,6 +34,8 @@
 using namespace std;
 
 string minerMode;       //solo or stratum
+string statURL;
+string minerName;
 int stratumSocket;      //tcp connected socket for stratum mode
 
 multimap<string, string> commandArgs;
@@ -109,6 +111,8 @@ void showUsage(const char* message) {
     printf("  -wallet <wallet address>   [only used for solo]\n");
     printf("  -miner <miner params>\n");
     printf("  -hiveos [0|1]   [optional, if 1 will format output for hiveos]\n");
+    printf("  -statrpcurl <URL to send stats to> [optional]\n");
+    printf("  -minername <display name of miner> [required with statrpcurl]\n");
     printf("\n");
     printf("<miner params> format:\n");
     printf("  [CPU|GPU],<cores or compute units>[<work size>,<platform id>,<device id>[,<loops>]]\n");
@@ -147,6 +151,20 @@ void parseCommandArgs(int argc, char* argv[]) {
         if (modeTypes.find(mode) == modeTypes.end())
             showUsage("Invalid MODE argument");
         minerMode = mode;
+    }
+
+    if (commandArgs.find("-statrpcurl") != commandArgs.end()) {
+        multimap<string, string>::iterator it = commandArgs.find("-statrpcurl");
+        statURL = it->second;
+        if (commandArgs.find("-minername") == commandArgs.end())
+            showUsage("-minername is required when using -statrpcurl");
+
+        printf("Sending stats to URL: %s \n", statURL.c_str());
+    }
+
+    if (commandArgs.find("-minername") != commandArgs.end()) {
+        multimap<string, string>::iterator it = commandArgs.find("-minername");
+        minerName = it->second;
     }
 
     if (commandArgs.find("-server") == commandArgs.end())
@@ -204,7 +222,7 @@ void startSubmitter() {
 
 void startStatDisplay() {
  
-    thread statThread(&cStatDisplay::displayStats, statDisplay, submitter, minerMode, rpcConfigParams.hiveos);
+    thread statThread(&cStatDisplay::displayStats, statDisplay, submitter, minerMode, rpcConfigParams.hiveos, statURL, minerName);
     statThread.detach();
 }
 

--- a/DynMiner2/cStatDisplay.cpp
+++ b/DynMiner2/cStatDisplay.cpp
@@ -1,5 +1,6 @@
 #include "cStatDisplay.h"
 #include "cSubmitter.h"
+#include <iostream>
 
 string cStatDisplay::seconds_to_uptime(int n) {
     int days = n / (24 * 3600);
@@ -31,7 +32,7 @@ string cStatDisplay::seconds_to_uptime(int n) {
     return (uptimeString);
 }
 
-void cStatDisplay::displayStats(cSubmitter *submitter, string mode, int hiveos) {
+void cStatDisplay::displayStats(cSubmitter *submitter, string mode, int hiveos, string statURL, string minerName) {
 
     totalStats = new cStats();
 
@@ -73,6 +74,40 @@ void cStatDisplay::displayStats(cSubmitter *submitter, string mode, int hiveos) 
                 sprintf(display, "%.2f H/s", hashrate);
 
             std::string uptime = seconds_to_uptime(difftime(now, start));
+
+	    if (!statURL.empty()) {
+
+	        curl = curl_easy_init();
+	        curl_easy_setopt(curl, CURLOPT_URL, statURL.c_str());
+
+	        string hashStr = to_string(int(hashrate));
+
+	        char postString[320];
+
+	        sprintf(postString, R"(
+	                    {
+			     "Name": "%s",
+			     "Hashrate": %s,
+			     "Submit": %4lu,
+			     "Accept": %-4d,
+			     "Reject": %4d,
+			     "Diff": %-4d
+			    }
+					  )",
+			minerName.c_str(), hashStr.c_str(),
+                totalStats->share_count.load(std::memory_order_relaxed), totalStats->accepted_share_count.load(std::memory_order_relaxed),
+                totalStats->rejected_share_count.load(std::memory_order_relaxed), totalStats->latest_diff.load(std::memory_order_relaxed));
+
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postString);
+
+		res = curl_easy_perform(curl);
+
+		if (res != CURLE_OK)
+		    fprintf(stderr, "Unable to connect to stat reporting ip: %s\n", curl_easy_strerror(res));
+
+		curl_easy_cleanup(curl);
+
+	    }
 
             SET_COLOR(LIGHTBLUE);
             printf("%s: ", timestamp);

--- a/DynMiner2/cStatDisplay.cpp
+++ b/DynMiner2/cStatDisplay.cpp
@@ -38,6 +38,8 @@ void cStatDisplay::displayStats(cSubmitter *submitter, string mode, int hiveos, 
 
     time_t now;
     time_t start;
+    CURL* curl;
+    CURLcode res;
 
     time(&start);
 

--- a/DynMiner2/cStatDisplay.h
+++ b/DynMiner2/cStatDisplay.h
@@ -45,8 +45,6 @@ public:
     void addCard(string key);
 
     string seconds_to_uptime(int n);
-    CURL* curl;
-    CURLcode res;
 
     cStats* totalStats;
     std::map<string, cStats*> perCardStats;

--- a/DynMiner2/cStatDisplay.h
+++ b/DynMiner2/cStatDisplay.h
@@ -13,8 +13,13 @@ class cSubmitter;
 
 using namespace std;
 
+#ifdef __linux__
+#include "curl/curl.h"
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
+#include <curl\curl.h>
 #define SET_COLOR(color) SetConsoleTextAttribute(hConsole, color);
 #include "Windows.h"
 #else
@@ -36,10 +41,12 @@ class cStatDisplay
 {
 
 public:
-	void displayStats(cSubmitter* submitter, string mode, int hiveos);
+	void displayStats(cSubmitter* submitter, string mode, int hiveos, string statURL, string minerName);
     void addCard(string key);
 
     string seconds_to_uptime(int n);
+    CURL* curl;
+    CURLcode res;
 
     cStats* totalStats;
     std::map<string, cStats*> perCardStats;

--- a/DynMiner2/cSubmitter.h
+++ b/DynMiner2/cSubmitter.h
@@ -63,6 +63,8 @@ public:
 	cStatDisplay* statDisplay;
 
 	string minerMode;
+	string statURL;
+	string minerName;
 
 	CURL* curl;
 	CURLcode res;


### PR DESCRIPTION
Add new command line option to enable sending stat data via rpc to remote monitoring app.
Also add new command line option to 'name' the miner, with the name being send to the monitor.